### PR TITLE
chore: fix build

### DIFF
--- a/packages/nativescript-highcharts/angular/highcharts.directive.ts
+++ b/packages/nativescript-highcharts/angular/highcharts.directive.ts
@@ -1,8 +1,6 @@
 import { Directive } from '@angular/core';
 
 @Directive({
-  selector: 'Highcharts'
+	selector: 'Highcharts',
 })
 export class HighchartsDirective {}
-
-export const DIRECTIVES = HighchartsDirective;

--- a/packages/nativescript-highcharts/angular/index.ts
+++ b/packages/nativescript-highcharts/angular/index.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { registerElement } from '@nativescript/angular';
 import { Highcharts } from '@mhtghn/nativescript-highcharts';
-import { DIRECTIVES } from './highcharts.directive';
+import { HighchartsDirective } from './highcharts.directive';
 
 @NgModule({
-  declarations: [DIRECTIVES],
-  exports: [DIRECTIVES]
+	declarations: [HighchartsDirective],
+	exports: [HighchartsDirective],
 })
 export class HighchartsModule {}
 

--- a/packages/nativescript-highcharts/angular/package.json
+++ b/packages/nativescript-highcharts/angular/package.json
@@ -6,7 +6,7 @@
 			"umdModuleIds": {
 				"@nativescript/core": "ns-core",
 				"@nativescript/angular": "ns-angular",
-				"@mhtghn/nativescript-highcharts": "@mhtghn/nativescript-highcharts"
+				"@mhtghn/nativescript-highcharts": "ns-highcharts-angular"
 			}
 		},
 		"whitelistedNonPeerDependencies": [

--- a/packages/nativescript-highcharts/index.ts
+++ b/packages/nativescript-highcharts/index.ts
@@ -1,10 +1,9 @@
 import { Builder, FlexboxLayout, Property, View, WebView } from '@nativescript/core';
 
-
 export const optionsProperty = new Property<Highcharts, string>({
-  name: 'options',
-  valueConverter: value => {
-    return `
+	name: 'options',
+	valueConverter: (value) => {
+		return `
             <!DOCTYPE html>
             <head>
                 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
@@ -883,37 +882,37 @@ v[l]="undefined"===typeof q[l]?null:q[l]})}var n=this,v={};f(a,this.options,v,0)
             Highcharts.chart('container', ${value});
             </script>
             </body></html>`;
-  },
-  defaultValue: ''
+	},
+	defaultValue: '',
 });
 
 export class Highcharts extends FlexboxLayout {
-  constructor() {
-    super();
-    let innerComponent = Builder.parse(<string>require('./common.xml')) as View;
-    innerComponent.bindingContext = this;
+	constructor() {
+		super();
+		let innerComponent = Builder.parse(<string>require('./common.xml')) as View;
+		innerComponent.bindingContext = this;
 
-    this.addChild(innerComponent);
-  }
+		this.addChild(innerComponent);
+	}
 
-  onWebViewLoaded(webargs) {
-    const webview: WebView = <WebView> webargs.object;
-    webview.on(WebView.loadFinishedEvent, (args) => {
-      if (webview.android) {
-        webview.android.getSettings().setBuiltInZoomControls(false);
-        webview.android.getSettings().setDisplayZoomControls(false);
-        webview.android.setBackgroundColor(0x00000000);
-        webview.android.setLayerType(android.view.View.LAYER_TYPE_SOFTWARE, null);
-      } else {
-        webview.ios.scrollView.minimumZoomScale = 1.0;
-        webview.ios.scrollView.maximumZoomScale = 1.0;
-        webview.ios.scalesPageToFit = false;
-        webview.ios.scrollView.bounces = false;
-        webview.ios.backgroundColor = UIColor.clearColor;
-        webview.ios.opaque = false;
-      }
-    });
-  }
+	onWebViewLoaded(webargs) {
+		const webview: WebView = <WebView>webargs.object;
+		webview.on(WebView.loadFinishedEvent, (args) => {
+			if (webview.android) {
+				webview.android.getSettings().setBuiltInZoomControls(false);
+				webview.android.getSettings().setDisplayZoomControls(false);
+				webview.android.setBackgroundColor(0x00000000);
+				webview.android.setLayerType(android.view.View.LAYER_TYPE_SOFTWARE, null);
+			} else {
+				webview.ios.scrollView.minimumZoomScale = 1.0;
+				webview.ios.scrollView.maximumZoomScale = 1.0;
+				webview.ios.scalesPageToFit = false;
+				webview.ios.scrollView.bounces = false;
+				webview.ios.backgroundColor = UIColor.clearColor;
+				webview.ios.opaque = false;
+			}
+		});
+	}
 }
 
 optionsProperty.register(Highcharts);

--- a/packages/nativescript-highcharts/package.json
+++ b/packages/nativescript-highcharts/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "@mhtghn/nativescript-highcharts",
 	"version": "1.0.0",
-  "description": "This plugins allows you to use Highcharts in NativeScript.",
-	"main": "common",
+	"description": "This plugins allows you to use Highcharts in NativeScript.",
+	"main": "index",
 	"typings": "index.d.ts",
 	"nativescript": {
 		"platforms": {

--- a/workspace.json
+++ b/workspace.json
@@ -103,6 +103,7 @@
 						"assets": [
 							"packages/nativescript-highcharts/*.md",
 							"packages/nativescript-highcharts/index.d.ts",
+							"packages/nativescript-highcharts/common.xml",
 							"LICENSE",
 							{
 								"glob": "**/*",


### PR DESCRIPTION
Great plugin @mhtghn nice work 👏 

This does some minor cleanup and fixes the build.
Primarily the issue was that the node builder will always by default expect an `index.ts` as the entry. This is identified/defined in the `workspace.json` here:

```
"nativescript-highcharts": {
  ...
  "architect": {
    "build": {
      ...
      "options": {
        ...
        "main": "packages/nativescript-highcharts/index.ts",  <-- This sets the package.json "main" in dist/packages output
``` 

We could have also pointed that at `common.ts` but for consistency I just renamed that to `index.ts` so it's streamlined like everything else.

The last thing was that we wanted to make sure `common.xml` was copied into the dist output. By default the node builder is configured to build `.ts` files and thus will output it's emitted `.js` files to dist. That's just the default behavior. As you can see in the changeset here you can easily define `assets` which are to be copied to the dist output with the package. For single 1-1 files they can just simply be listed:

```
"assets": [
  "packages/nativescript-highcharts/*.md",
  "packages/nativescript-highcharts/index.d.ts",
  "packages/nativescript-highcharts/common.xml", <-- I added this :)
```

You can also take advantage of object based asset definitions as you'll see is predefined as:

```
{
	"glob": "**/*",
	"input": "packages/nativescript-highcharts/platforms/",
	"output": "./platforms/"
}
```

For example that ensures if platforms folder exits that it would copy entire contents to the dist output along with the nicely built package output. You can use same strategy for any collection of assets that need to make it to dist.

I'll write a blog post on this and other powerful things you can configure for all sorts of plugin use cases this week.

After merging/pulling go ahead and `npm run setup` then `npm start` > demo-angular.clean > then build the plugin fresh and then run your angular demo.

<img width="449" alt="Screen Shot 2020-09-19 at 5 49 16 PM" src="https://user-images.githubusercontent.com/457187/93691975-dd6fed00-faa1-11ea-9109-69894463eeb2.png">
